### PR TITLE
chore(renovate): adopt shared github>LukeEvansTech/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,38 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "labels": [
-    "dependencies"
-  ],
+  "extends": ["github>LukeEvansTech/renovate-config"],
+  "schedule": ["before 6am on monday"],
   "pip_requirements": {
-    "managerFilePatterns": [
-      "/webapp/requirements.txt/"
-    ]
-  },
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "automerge": false
-    }
-  ],
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": [
-      "security"
-    ]
-  },
-  "schedule": [
-    "before 6am on monday"
-  ]
+    "managerFilePatterns": ["/webapp/requirements.txt/"]
+  }
 }


### PR DESCRIPTION
Switches this repo to the shared Renovate config at https://github.com/LukeEvansTech/renovate-config (which layers house defaults on `home-operations/renovate-presets#2.0.0`). Repo-specific settings are preserved below the `extends` line. Automerge is now GitHub-Actions-only (per the shared config); everything else opens a PR to review.