### PR TITLE
chore(renovate): migrate renovate.json → .renovaterc.json5

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>LukeEvansTech/renovate-config"],
+  "schedule": ["before 6am on monday"],
+  "pip_requirements": {
+    "managerFilePatterns": ["/webapp/requirements.txt/"]
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>LukeEvansTech/renovate-config"],
-  "schedule": ["before 6am on monday"],
-  "pip_requirements": {
-    "managerFilePatterns": ["/webapp/requirements.txt/"]
-  }
-}


### PR DESCRIPTION
Renames the Renovate config file for fleet consistency (`.renovaterc.json5` is the house-standard filename).

- **Content unchanged** — still extends `github>LukeEvansTech/renovate-config` plus the existing `schedule` and `pip_requirements` overrides.
- Validated with `renovate-config-validator` (renovate@latest).

Config-only; no change to dependency-update behavior.