### PR TITLE
fix(renovate): format .renovaterc.json5 to prettier json5 style

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>LukeEvansTech/renovate-config"],
-  "schedule": ["before 6am on monday"],
-  "pip_requirements": {
-    "managerFilePatterns": ["/webapp/requirements.txt/"]
-  }
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>LukeEvansTech/renovate-config"],
+  schedule: ["before 6am on monday"],
+  pip_requirements: {
+    managerFilePatterns: ["/webapp/requirements.txt/"],
+  },
 }


### PR DESCRIPTION
Reformats `.renovaterc.json5` to the json5 style Prettier infers from the
`.json5` extension — unquoted object keys + trailing comma — which clears
super-linter's `JSONC_PRETTIER` check.

**Cosmetic only:** the JSON is semantically identical and Renovate accepts
both forms. No behavior change.

Part of a fleet-wide sweep standardizing `.renovaterc.json5` formatting across
the renovate-config fleet.